### PR TITLE
Fix logical errors in example

### DIFF
--- a/_sources/04_Loops/combining_loops_and_conditionals.rst
+++ b/_sources/04_Loops/combining_loops_and_conditionals.rst
@@ -13,7 +13,7 @@ We know that we can determine whether an integer is even or odd by the modulus o
     max_number = input("Print all positive even numbers less than:")
     max_number = int(max_number)
 
-    for candidate in range(max_number + 1):
+    for candidate in range(1, max_number):
 
         # test for evenness
         if candidate % 2 == 0:


### PR DESCRIPTION
This fixes two inconsistencies between the input text and the results in the first activecode example. 

If the desired results is a list of "all positive even numbers less than" the input, then the results should not include zero or the input. 
Zero is unsigned, neither positive nor negative. The input number should only be included if the text was "less than or equal to".